### PR TITLE
feat: add pdf upload viewer with coordinate tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Navbar from "./components/Navbar";
 import BlankCanvasPage from "./pages/BlankCanvasPage";
 import HomePage from "./pages/HomePage";
 import NotFoundPage from "./pages/NotFoundPage";
+import PdfUploadPage from "./pages/PdfUploadPage";
 
 const router = createBrowserRouter([
   {
@@ -14,6 +15,10 @@ const router = createBrowserRouter([
   {
     path: "/blank-canvas",
     element: <BlankCanvasPage />,
+  },
+  {
+    path: "/upload-pdf",
+    element: <PdfUploadPage />,
   },
 ]);
 function App() {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,7 +5,10 @@ import CancelIcon from "../icons/CancelIcon";
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   let pathname = window.location.pathname;
-  pathname = pathname === "/blank-canvas" ? "/" : pathname;
+  pathname =
+    pathname === "/blank-canvas" || pathname === "/upload-pdf"
+      ? "/"
+      : pathname;
 
   const getNavItemClass = (route: string) => {
     return pathname === route

--- a/src/components/SelectionCard.tsx
+++ b/src/components/SelectionCard.tsx
@@ -17,7 +17,11 @@ const SelectionCard = () => {
           color="hsl(var(--yellow))"
           toLink="blank-canvas"
         />
-        <Card hoverText="Upload" color="hsl(var(--lightorange))" toLink="/">
+        <Card
+          hoverText="Upload"
+          color="hsl(var(--lightorange))"
+          toLink="upload-pdf"
+        >
           <UploadIcon />
         </Card>
         <div className="absolute top-[10%] -left-[6%] md:top-[78%] md:left-[68%] -z-10 lg:left-[59%] lg:top-[72%] ">

--- a/src/pages/PdfUploadPage.tsx
+++ b/src/pages/PdfUploadPage.tsx
@@ -1,0 +1,96 @@
+import { useMemo, useState, useEffect } from "react";
+import AdvertisementCard from "../components/AdvertisementCard";
+import OutputCard from "../components/OutputCard";
+import MobileOutputCard from "../components/MobileOutputCard";
+
+const PdfUploadPage = () => {
+  const [file, setFile] = useState<File | null>(null);
+  const [fileUrl, setFileUrl] = useState<string | null>(null);
+  const [coordinates, setCoordinates] = useState({ x: 0, y: 0 });
+  const [coordinatesBy1, setCoordinatesBy1] = useState({ x: 0, y: 0 });
+  const [coordinatesBy10, setCoordinatesBy10] = useState({ x: 0, y: 0 });
+
+  const handleMouseMove = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    const normalizedXBy1 = ((x / rect.width) * 1).toFixed(2);
+    const normalizedYBy1 = ((y / rect.height) * 1).toFixed(2);
+    const normalizedXBy10 = ((x / rect.width) * 10).toFixed(2);
+    const normalizedYBy10 = ((y / rect.height) * 10).toFixed(2);
+    setCoordinates({ x, y });
+    setCoordinatesBy1({
+      x: Number.parseFloat(normalizedXBy1),
+      y: Number.parseFloat(normalizedYBy1),
+    });
+    setCoordinatesBy10({
+      x: Number.parseFloat(normalizedXBy10),
+      y: Number.parseFloat(normalizedYBy10),
+    });
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = e.target.files ? e.target.files[0] : null;
+    setFile(selectedFile);
+  };
+
+  useEffect(() => {
+    if (file) {
+      const url = URL.createObjectURL(file);
+      setFileUrl(url);
+      return () => {
+        URL.revokeObjectURL(url);
+      };
+    }
+    setFileUrl(null);
+  }, [file]);
+
+  const advertisementCard = useMemo(() => <AdvertisementCard />, []);
+
+  return (
+    <div className="flex flex-col md:flex-row h-full pt-14">
+      <div className="w-72 p-2 hidden md:block">
+        <OutputCard
+          coordinates={coordinates}
+          coordinatesBy1={coordinatesBy1}
+          coordinatesBy10={coordinatesBy10}
+        />
+      </div>
+      <div className="flex-1 flex flex-col justify-center p-2 items-center gap-4">
+        <input
+          type="file"
+          accept="application/pdf"
+          onChange={handleFileChange}
+          className="mb-4"
+        />
+        {fileUrl ? (
+          <div
+            className="relative h-[450px] md:h-[600px] max-w-screen-md aspect-[1/1.414] border-2 border-solid border-black"
+          >
+            <embed src={fileUrl} type="application/pdf" className="w-full h-full" />
+            <div
+              className="absolute top-0 left-0 w-full h-full"
+              onMouseMove={handleMouseMove}
+            />
+          </div>
+        ) : (
+          <p className="text-center text-black font-bold mt-2">
+            Upload a PDF to begin
+          </p>
+        )}
+      </div>
+      <div className="w-[20%]  p-2 hidden md:block">{advertisementCard}</div>
+      <div className=" md:hidden p-2">
+        <MobileOutputCard
+          coordinates={coordinates}
+          coordinatesBy1={coordinatesBy1}
+          coordinatesBy10={coordinatesBy10}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PdfUploadPage;


### PR DESCRIPTION
## Summary
- add page to upload and display a PDF with cursor coordinate tracking
- link new PDF viewer into router, selection card, and navbar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a58e560a148323b5699df12f857a97